### PR TITLE
Update to pronto 0.4.x and coffee lint 1.8.x

### DIFF
--- a/pronto-coffeelint.gemspec
+++ b/pronto-coffeelint.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -- {spec}/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_dependency 'pronto', '~> 0.3.0'
-  s.add_dependency 'coffeelint', '~> 0.3.0'
+  s.add_dependency 'pronto', '~> 0.4.0'
+  s.add_dependency 'coffeelint', '~> 1.8.0'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its', '~> 1.0'


### PR DESCRIPTION
Since pronto and coffeelint released newer versions dependencies have to be updated. 
