### PR TITLE
Updates dependencies

### DIFF
--- a/lib/pronto/coffeelint/version.rb
+++ b/lib/pronto/coffeelint/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module CoffeelintVersion
-    VERSION = '0.0.4'
+    VERSION = '0.5.0'
   end
 end

--- a/pronto-coffeelint.gemspec
+++ b/pronto-coffeelint.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -- {spec}/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_dependency 'pronto', '~> 0.4'
-  s.add_dependency 'coffeelint', '~> 1.11'
+  s.add_dependency 'pronto', '~> 0.5'
+  s.add_dependency 'coffeelint', '~> 1.14'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its', '~> 1.0'


### PR DESCRIPTION
- Updates gem dependencies for pronto and coffeelint
- Bumps version to 0.5.0, which falls in line with the other runners matching the minor version of Pronto
